### PR TITLE
feat: new method `as_hash_map`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,11 @@ impl TextParts {
 
         qs.finish()
     }
+    
+    /// Returns `HashMap`  of field names and values
+    pub fn as_hash_map(&self) -> HashMap<_, _> {
+        self.as_pairs().into_iter().collect()
+    }
 }
 
 impl FileParts {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@ use tempfile::NamedTempFile;
 
 use std::io::{Cursor, Write};
 use std::path::{Path, PathBuf};
+use std::collections::HashMap;
 
 #[cfg(feature = "v1")]
 pub mod v1;
@@ -169,7 +170,8 @@ impl TextParts {
     }
     
     /// Returns `HashMap`  of field names and values
-    pub fn as_hash_map(&self) -> HashMap<_, _> {
+    /// NOTE: this will discard the first of multiple values for a key
+    pub fn as_hash_map(&self) -> HashMap {
         self.as_pairs().into_iter().collect()
     }
 }


### PR DESCRIPTION
```rust
let q: HashMap<_, _> = parts.texts.as_hash_map();
```

Closes #6 